### PR TITLE
Install macOS SDK header for Mojave

### DIFF
--- a/mac
+++ b/mac
@@ -13,6 +13,9 @@ cd "$HOME"
 # xcode-select --install
 # sudo xcodebuild -license
 
+# It seems that the latest version of xcode-select (2354) does not include macOS SDK header for Mojave by default.
+sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+
 fancy_echo "Create $HOME/Tools directory"
 if [ ! -d "$HOME/Tools" ]; then
   mkdir "$HOME/Tools"


### PR DESCRIPTION
It seems that the latest version of xcode-select (2354) does not include macOS SDK header for Mojave by default.

Refs.
- https://qiita.com/zreactor/items/c3fd04417e0d61af0afe
- https://qiita.com/gengogo5/items/815869416eaee3bb8daa