### PR TITLE
Use the latest ruby version at that time

### DIFF
--- a/mac
+++ b/mac
@@ -189,7 +189,7 @@ brew install rbenv --HEAD
 brew link rbenv
 brew install rbenv-default-gems
 
-latest_ruby_version='2.5.1'
+latest_ruby_version="$(rbenv install -l | grep -E '^\s+(\d+\.\d+)\.\d+$' | tail -n 1)
 if ! [[ $(rbenv version | grep $latest_ruby_version) ]]; then
   rbenv install $latest_ruby_version
 fi


### PR DESCRIPTION
Get the version with script rather than specifying it with literal.