### PR TITLE
Install a latest "maintenance release" perl, instead of an "UNSTABLE DEVELOPMENT" release

### DIFF
--- a/mac
+++ b/mac
@@ -212,7 +212,7 @@ if [ ! -d "$HOME/.plenv" ]; then
   mkdir "$HOME/.plenv"
 fi
 git clone git://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
-latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | head -n 1)
+latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1)
 plenv install $latest_perl5_version
 plenv global $latest_perl5_version
 plenv rehash


### PR DESCRIPTION
Avoid an install error.

The error was:
```
$ plenv install 5.29.8
Installing 5.29.8 as 5.29.8
/usr/local/Cellar/perl/5.28.1/bin/perl -- /Users/machupicchubeta/.plenv/plugins/perl-build/bin/perl-build --symlink-devel-executables --build-dir /Users/machupicchubeta/.plenv/build/1552803620.93045/ --tarball-dir /Users/machupicchubeta/.plenv/cache/ -Dversiononly 5.29.8 /Users/machupicchubeta/.plenv/versions/5.29.8
Fetching 5.29.8 as /Users/machupicchubeta/.plenv/cache/perl-5.29.8.tar.gz (https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/perl-5.29.8.tar.gz)
Downloaded https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/perl-5.29.8.tar.gz to /Users/machupicchubeta/.plenv/cache/perl-5.29.8.tar.gz.
Configuring perl '5.29.8'
rm -f config.sh Policy.sh
Auto-guessed '5.29.8'
patching Configure
sh Configure -Dprefix=/Users/machupicchubeta/.plenv/versions/5.29.8 -de -Dversiononly -A'eval:scriptdir=/Users/machupicchubeta/.plenv/versions/5.29.8/bin'

Beginning of configuration questions for perl5.

Checking echo to see how to suppress newlines...
...using \c
The star should be here-->*

First let's make sure your kit is complete.  Checking...
Looks good...
*** WHOA THERE!!! ***

    This is an UNSTABLE DEVELOPMENT release.
    The version of this perl5 distribution is 29, that is, odd,
    (as opposed to even) and that signifies a development release.
    If you want a maintenance release, you want an even-numbered version.

    Do ***NOT*** install this into production use.
    Data corruption and crashes are possible.

    It is most seriously suggested that you do not continue any further
    unless you want to help in developing and debugging Perl.

    If you *still* want to build perl, you can answer 'y' now,
    or pass -Dusedevel to Configure.

Do you really want to continue? [n]
Okay, bye.
Installation failure: sh Configure -Dprefix=/Users/machupicchubeta/.plenv/versions/5.29.8 -de -Dversiononly -A'eval:scriptdir=/Users/machupicchubeta/.plenv/versions/5.29.8/bin' at /Users/machupicchubeta/.plenv/plugins/perl-build/bin/perl-build line 10353.
ABORT
```