### PR TITLE
Get rid of an annoying blank

### DIFF
--- a/mac
+++ b/mac
@@ -212,7 +212,7 @@ if [ ! -d "$HOME/.plenv" ]; then
   mkdir "$HOME/.plenv"
 fi
 git clone git://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
-latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1)
+latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1 | sed -e 's/^[ ]*//g')
 plenv install $latest_perl5_version
 plenv global $latest_perl5_version
 plenv rehash


### PR DESCRIPTION
Aviod an eror, that was:
```
$ latest_perl5_version=$(plenv install -l | grep -E '^\s+5\.\d+\.\d+$' | awk -F'[.]' '{ if ($2 %2 == 0) print $0 }' | head -n 1)
$ echo $latest_perl5_version
 5.28.1
$ plenv install $latest_perl5_version
Installing  5.28.1 as  5.28.1
/usr/local/Cellar/perl/5.28.1/bin/perl -- /Users/machupicchubeta/.plenv/plugins/perl-build/bin/perl-build --symlink-devel-executables --build-dir /Users/machupicchubeta/.plenv/build/1552805744.98329/ --tarball-dir /Users/machupicchubeta/.plenv/cache/ -Dversiononly  5.28.1 /Users/machupicchubeta/.plenv/versions/ 5.28.1
[cpan_perl_releases] not found the tarball for perl- 5.28.1
[metacpan] not found the tarball for perl- 5.28.1
ERROR: Cannot find the tarball for perl- 5.28.1
ABORT
```