### PR TITLE
Make San Francisco Mono font available in editor apps

### DIFF
--- a/mac
+++ b/mac
@@ -71,6 +71,9 @@ if [ ! -d "$HOME/bin" ]; then
   mkdir "$HOME/bin"
 fi
 
+fancy_echo "Copy SFMono fonts to User font directory"
+cp -f /Applications/Utilities/Terminal.app/Contents/Resources/Fonts/*.otf $HOME/Library/Fonts/
+
 fancy_echo "Create symbolic links on $HOME"
 for dot_file in $(find "$HOME"/Tools/dotfiles/.* -type f -d 0); do
   dot_filename=$(basename "$dot_file")


### PR DESCRIPTION
See also:
- https://medium.com/@shashikant.jagtap/getting-apples-sf-mono-font-in-macos-1de5183add84
- https://qiita.com/usagimaru/items/da88c0a8793f23633c28
- https://support.apple.com/en-gb/HT201722