### PR TITLE
Run `brew` commands in another process

### DIFF
--- a/mac
+++ b/mac
@@ -225,7 +225,7 @@ plenv global $latest_perl5_version
 plenv rehash
 
 fancy_echo "Install Libraries and Tools via homebrew"
-. "$HOME/Tools/dotfiles/bin/brewfile.sh"
+bash $HOME/Tools/dotfiles/bin/brewfile.sh
 
 fancy_echo "Load $HOME/.laptop.local"
 if [ -f "$HOME/.laptop.local" ]; then


### PR DESCRIPTION
When running `brew` commands in the same process, it stops at warning.