### PR TITLE
Seems no longer needed to install command  line tools headers

### DIFF
--- a/mac
+++ b/mac
@@ -17,9 +17,6 @@ if ! [[ $(xcodebuild -version | grep -E '^Xcode \d+\.\d+$') ]]; then
   sudo xcodebuild -license
 fi
 
-# It seems that the latest version of xcode-select (2354) does not include macOS SDK header for Mojave by default.
-sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-
 fancy_echo "Create $HOME/Tools directory"
 if [ ! -d "$HOME/Tools" ]; then
   mkdir "$HOME/Tools"


### PR DESCRIPTION
`/usr/include` is deprecated since Xcode10.
- https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035624
> The command line tools will search the SDK for system headers by default. However, some software may fail to build correctly against the SDK and require macOS headers to be installed in the base system under /usr/include. If you are the maintainer of such software, we encourage you to update your project to work with the SDK or file a bug report for issues that are preventing you from doing so.

- https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035624
> As a workaround, an extra package is provided which will install the headers to the base system. In a future release, this package will no longer be provided.

I resolved pyenv build error by installing command line tools.
- https://github.com/pyenv/pyenv/issues/1066#issuecomment-538201389

`/usr/include` is under `xcrun --show-sdk-path` if I want to use it.
- https://qiita.com/yoya/items/c0b26cba3c040c581643