### PR TITLE
Update the place of "Terminal.app" in "Catalina"

### DIFF
--- a/mac
+++ b/mac
@@ -70,7 +70,7 @@ defaults write com.apple.screencapture location "$HOME/Screenshots"
 killall SystemUIServer
 
 echo "\nCopy SFMono fonts to User font directory\n"
-cp -f /Applications/Utilities/Terminal.app/Contents/Resources/Fonts/*.otf $HOME/Library/Fonts/
+cp -f /System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/*.otf $HOME/Library/Fonts/
 
 echo "\nDownload settings\n"
 SETUP_PATH="$HOME/setup"


### PR DESCRIPTION
```
$ls /System/Applications/Utilities
Activity Monitor.app		Bluetooth File Exchange.app	Console.app			Grapher.app			Screenshot.app			Terminal.app
AirPort Utility.app		Boot Camp Assistant.app		Digital Color Meter.app		Keychain Access.app		Script Editor.app		VoiceOver Utility.app
Audio MIDI Setup.app		ColorSync Utility.app		Disk Utility.app		Migration Assistant.app		System Information.app
```

```
$ls /System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts 
SFMono-Bold.otf			SFMono-Heavy.otf		SFMono-Light.otf		SFMono-Medium.otf		SFMono-Regular.otf		SFMono-Semibold.otf
SFMono-BoldItalic.otf		SFMono-HeavyItalic.otf		SFMono-LightItalic.otf		SFMono-MediumItalic.otf		SFMono-RegularItalic.otf	SFMono-SemiboldItalic.otf
```