### PR TITLE
Run `xcode-select --install` if necessary

### DIFF
--- a/mac
+++ b/mac
@@ -12,7 +12,9 @@ fi
 
 echo "\nInstall Xcode command line tools\n"
 sudo xcodebuild -license
-xcode-select --install
+if ! [[ $(xcode-select -v | grep -E '^xcode-select version \d+\.$') ]]; then
+  xcode-select --install
+fi
 
 echo "\nInstall Homebrew\n"
 if [ ! -x "$(command -v brew)" ]; then


### PR DESCRIPTION
An error occurs if it is already installed.
```
xcode-select: error: command line tools are already installed, use "Software Update" to install updates
```