### PR TITLE
Avoid `unbound variable` error

### DIFF
--- a/mac
+++ b/mac
@@ -109,6 +109,7 @@ for dot_directory in $(find $SETTINGS_PATH/.* -type d -d 0 ! -path "$SETTINGS_PA
   fi
   ln -s "$dot_directory" "$HOME/$dot_directory_name"
 done
+: ${XDG_CONFIG_HOME:=$HOME/.config}
 if [ ! -d "$XDG_CONFIG_HOME" ]; then
   mkdir "$XDG_CONFIG_HOME"
 fi


### PR DESCRIPTION
Error was:
```
/dev/fd/11: line 112: XDG_CONFIG_HOME: unbound variable
```

Ref.
- https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html
- https://wiki.archlinux.org/index.php/XDG_Base_Directory
- https://gist.github.com/doi-t/7853853
- https://stackoverflow.com/questions/2013547/assigning-default-values-to-shell-variables-with-a-single-command-in-bash