### PR TITLE
Stop to use "Homebrew Bundle"

### DIFF
--- a/mac
+++ b/mac
@@ -16,7 +16,7 @@ if [ ! -x "$(command -v brew)" ]; then
 fi
 
 echo "Install commands and Apps"
-curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/master/Brewfile > $HOME/Brewfile && brew bundle && rm $HOME/Brewfile
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/master/bin/brewfile.sh)
 
 echo "Install oh-my-zsh"
 if [ ! -d "$HOME/.oh-my-zsh" ]; then


### PR DESCRIPTION
Use `brew` commands on shell script, instead of "Homebrew Bundle".

See also:
- https://github.com/machupicchubeta/dotfiles/commit/9fbe0a6d90ec2c530c1ffb94d401f6a253a61933