### PR TITLE
Rename the default branch from `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Usage
 
 ```
-bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/laptop/master/mac)
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/laptop/main/mac)
 ```


### PR DESCRIPTION
See also:
- https://sfconservancy.org/news/2020/jun/23/gitbranchname/
- https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch
- https://github.com/github/renaming#renaming-the-default-branch-from-master