### PR TITLE
Stop installing "Oh My Zsh"

### DIFF
--- a/mac
+++ b/mac
@@ -21,11 +21,6 @@ fi
 echo "Install commands and Apps"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/brewfile.sh)
 
-echo "Install oh-my-zsh"
-if [ ! -d "$HOME/.oh-my-zsh" ]; then
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
-fi
-
 echo "Create tmp directory"
 if [ ! -d "$HOME/tmp" ]; then
   mkdir "$HOME/tmp"
@@ -109,9 +104,6 @@ if [ -e /etc/my.cnf ]; then
   sudo mv /etc/my.cnf /etc/my.cnf_"$(date +%Y-%m-%dT%H:%M:%S%z)"
 fi
 sudo ln -s "$SETTINGS_PATH/mysql/my-utf8mb4.cnf" /etc/my.cnf
-if [ -L "$HOME/.zshrc.pre-oh-my-zsh" ]; then
-  unlink "$HOME/.zshrc.pre-oh-my-zsh"
-fi
 RBENV_PATH="$HOME/.rbenv"
 if [ ! -d "$RBENV_PATH" ]; then
   mkdir "$RBENV_PATH"


### PR DESCRIPTION
Use only libraries and plugins if necessary via `zplug`.

# See also:
- https://github.com/machupicchubeta/dotfiles/commit/5e2e7c7098ae3c2c5b1cb2507697220e23be685e
- https://github.com/machupicchubeta/dotfiles/pull/115

# After merge
- [ ] run `uninstall_oh_my_zsh`

## Refs.
- https://github.com/ohmyzsh/ohmyzsh#uninstalling-oh-my-zsh

> If you want to uninstall `oh-my-zsh`, just run `uninstall_oh_my_zsh` from the command-line. It will remove itself and revert your previous `bash` or `zsh` configuration.