### PR TITLE
Wipe out "tmux-powerline"

### DIFF
--- a/mac
+++ b/mac
@@ -62,7 +62,6 @@ ghq get -u github.com/machupicchubeta/diceware
 ghq get -u github.com/altercation/solarized
 ghq get -u github.com/mbadolato/iTerm2-Color-Schemes
 ghq get -u github.com/seebi/dircolors-solarized
-ghq get -u github.com/erikw/tmux-powerline
 ghq get -u gist.github.com/4979906
 ghq get -u github.com/tony/tmux-config
 


### PR DESCRIPTION
Unfortunately, I never had a chance to use it.

See also:
- https://github.com/erikw/tmux-powerline/blob/master/README.md

> DEPRECATION WARNING
> This project is in a maintenance mode and no future functionality is likely to be added. tmux-powerline, with all other powerline projects, is replaced by the new unifying powerline. However this project is still functional and can serve as a lightweight alternative for non-python users.
