### PR TITLE
Avoid glob expansion with using double quotes

### DIFF
--- a/mac
+++ b/mac
@@ -80,7 +80,7 @@ find "$SETTINGS_PATH"/.* -type d -d 0 ! -path "$SETTINGS_PATH/." ! -path "$SETTI
     fi
     ln -s "$dot_directory" "$HOME/$dot_directory_name"
   ' sh {} \;
-: ${XDG_CONFIG_HOME:=$HOME/.config}
+: "${XDG_CONFIG_HOME:=$HOME/.config}"
 if [ ! -d "$XDG_CONFIG_HOME" ]; then
   mkdir "$XDG_CONFIG_HOME"
 fi


### PR DESCRIPTION
Refs.
- https://github.com/koalaman/shellcheck/wiki/SC2223
