### PR TITLE
Get ready to setup Mac computers with Apple silicon

### DIFF
--- a/mac_with_apple_silicon
+++ b/mac_with_apple_silicon
@@ -2,8 +2,28 @@
 set -eu
 cd "$HOME"
 
-echo -e "\nLoad environment variables"
-source <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/.zsh/variables.zsh)
+echo -e "Load environment variables"
+curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/.zsh/variables.zsh -o "/tmp/variables.zsh"
+if [ -f '/tmp/variables.zsh' ]; then
+  source /tmp/variables.zsh
+  rm -f '/tmp/variables.zsh'
+fi
+
+echo -e "\nCheck CPU brand"
+: "${CPU_BRAND:=$(/usr/sbin/sysctl -n machdep.cpu.brand_string)}"
+echo $CPU_BRAND
+if [ -z "$(echo $CPU_BRAND | grep -o 'Apple')" ]; then
+  echo "Run commands as arm64 on this system is not supported."
+  exit 1
+fi
+
+echo -e "\nInstall Rosetta 2"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rosetta.sh)
+
+echo -e "\nMake sure to run as arm64 architecture"
+if [ "$(uname -m)" = "x86_64" ]; then
+  exec arch -arch arm64e "$SHELL"
+fi
 
 echo -e "\nEnable to sudo authenticate with touch id"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/enable_to_sudo_authenticate_with_touch_id.sh)
@@ -28,8 +48,8 @@ bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/mai
 echo -e "\nCopy SFMono fonts to User font directory"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_fonts.sh)
 
-echo -e "\nDownload settings and themes"
-bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/download_settings_and_themes.sh)
+echo -e "\nDownload settings"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/download_settings.sh)
 
 echo -e "\nPut settings"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/put_settings.sh)

--- a/mac_with_intel_processor
+++ b/mac_with_intel_processor
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -eu
+cd "$HOME"
+
+echo -e "Load environment variables"
+curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/.zsh/variables.zsh -o "/tmp/variables.zsh"
+if [ -f '/tmp/variables.zsh' ]; then
+  source /tmp/variables.zsh
+  rm -f '/tmp/variables.zsh'
+fi
+
+echo -e "\nCheck CPU brand"
+: "${CPU_BRAND:=$(/usr/sbin/sysctl -n machdep.cpu.brand_string)}"
+echo $CPU_BRAND
+
+echo -e "\nMake sure to run as x86_64 architecture"
+if [ "$(uname -m)" = "arm64" ]; then
+  exec arch -arch x86_64 "$SHELL"
+fi
+
+echo -e "\nEnable to sudo authenticate with touch id"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/enable_to_sudo_authenticate_with_touch_id.sh)
+
+echo -e "\nGenerate key pair"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/generate_key_pair.sh)
+
+echo -e "\nSetup Command Line Tools"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_command_line_tools.sh)
+
+echo -e "\nInstall Homebrew"
+if [ ! -x "$(command -v brew)" ]; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+fi
+
+echo -e "\nInstall commands and Apps"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/brewfile.sh)
+
+echo -e "\nSetup directories"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_directories.sh)
+
+echo -e "\nCopy SFMono fonts to User font directory"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_fonts.sh)
+
+echo -e "\nDownload settings"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/download_settings.sh)
+
+echo -e "\nPut settings"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/put_settings.sh)
+
+echo -e "\nPut scripts"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/put_scripts.sh)
+
+if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" ]; then
+  echo -e "Skip development language setup for under x86_64 arch settings.\nOn Apple silicon, please run under arm64 arch settings."
+else
+  echo -e "\nSetup Ruby"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_ruby.sh)
+
+  echo -e "\nSetup Python"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_python.sh)
+
+  echo -e "\nSetup Perl"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_perl.sh)
+
+  echo -e "\nSetup Java"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_java.sh)
+
+  echo -e "\nSetup Node.js"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_nodejs.sh)
+
+  echo -e "\nSetup Go"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_go.sh)
+
+  echo -e "\nSetup Rust"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rust.sh)
+
+  echo -e "\nSetup Terraform"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_terraform.sh)
+fi
+
+echo -e "\nApply private settings"
+if [ -f "$HOME/.laptop.local" ]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.laptop.local"
+fi
+
+echo -e "\nUse zsh installed via Homebrew as default shell"
+if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" ]; then
+  echo -e "Skip default shell setup for under x86_64 arch settings.\nOn Apple silicon, please run under arm64 arch settings."
+else
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_default_shell.sh)
+fi
+
+echo -e "\nLoad direnv"
+if which direnv > /dev/null; then direnv allow; fi


### PR DESCRIPTION
Enable to setup not only Mac computers with an Intel processor but also Mac computers with an Apple silicon.

I referenced these pages.
- https://zenn.dev/sprout2000/articles/aad599d3625242
- https://zenn.dev/ress/articles/069baf1c305523dfca3d
- https://oknm.jp/posts/e8cf774c2703c3677f0956ee10dc9ea2a8a9b47d
- https://titech-os.github.io/xv6-mac.html
- https://osxdaily.com/2020/12/04/how-install-rosetta-2-apple-silicon-mac/
- https://hkob.hatenablog.com/entry/2020/11/27/090000
- https://zenn.dev/hinastory/articles/71983c4ac8aa2d
- https://support.apple.com/en-us/HT211814
- https://forum.latenightsw.com/t/possible-for-a-script-to-test-whether-rosetta-2-is-installed/3207/6
- https://community.jamf.com/t5/jamf-pro/how-to-check-if-rosetta2-is-installed-macos-11-5/m-p/242580
- https://stackoverflow.com/questions/64908116/correct-archflags-value-on-apple-silicon
- https://gitlab.kitware.com/cmake/cmake/-/issues/20989
- https://news.ycombinator.com/item?id=25183120

See also:
- https://github.com/machupicchubeta/dotfiles/pull/351