### PR TITLE
Setup Rust first to enable YJIT in Ruby

### DIFF
--- a/mac_with_apple_silicon
+++ b/mac_with_apple_silicon
@@ -63,6 +63,9 @@ bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/mai
 echo -e "\nPut scripts"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/put_scripts.sh)
 
+echo -e "\nSetup Rust"
+bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rust.sh)
+
 echo -e "\nSetup Ruby"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_ruby.sh)
 
@@ -80,9 +83,6 @@ bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/mai
 
 echo -e "\nSetup Go"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_go.sh)
-
-echo -e "\nSetup Rust"
-bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rust.sh)
 
 echo -e "\nSetup Terraform"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_terraform.sh)

--- a/mac_with_intel_processor
+++ b/mac_with_intel_processor
@@ -55,6 +55,9 @@ bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/mai
 
 if [ -n "$(echo $CPU_BRAND | grep -o 'Apple')" ]; then
   echo -e "Skip development language setup for under x86_64 arch settings.\nOn Apple silicon, please run under arm64 arch settings."
+
+  echo -e "\nSetup Rust"
+  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rust.sh)
 else
   echo -e "\nSetup Ruby"
   bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_ruby.sh)
@@ -73,9 +76,6 @@ else
 
   echo -e "\nSetup Go"
   bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_go.sh)
-
-  echo -e "\nSetup Rust"
-  bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_rust.sh)
 
   echo -e "\nSetup Terraform"
   bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_terraform.sh)


### PR DESCRIPTION
Refs.
- https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html
- https://github.com/ruby/ruby/blob/8bbf909bb561732057b533cee1618b14886e07ba/doc/contributing/building_ruby.md
- https://github.com/ruby/ruby/blob/ruby_3_2/doc/yjit/yjit.md
- https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md#dependencies
- https://docs.ruby-lang.org/en/master/RubyVM/YJIT.html
- https://formulae.brew.sh/formula/ruby
- https://formulae.brew.sh/formula/rust

See also:
- https://github.com/machupicchubeta/dotfiles/commit/85452405f8dfa5a49acac466aef36d03e23cd2ea