### PR TITLE
Avoid .envrc file not found error

### DIFF
--- a/mac_with_apple_silicon
+++ b/mac_with_apple_silicon
@@ -100,4 +100,4 @@ echo -e "\nUse zsh installed via Homebrew as default shell"
 bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/main/bin/setup_default_shell.sh)
 
 echo -e "\nLoad direnv"
-if command -v direnv > /dev/null; then direnv allow; fi
+if command -v direnv > /dev/null && [ -f .envrc ]; then direnv allow; fi

--- a/mac_with_intel_processor
+++ b/mac_with_intel_processor
@@ -98,4 +98,4 @@ else
 fi
 
 echo -e "\nLoad direnv"
-if command -v direnv > /dev/null; then direnv allow; fi
+if command -v direnv > /dev/null && [ -f .envrc ]; then direnv allow; fi


### PR DESCRIPTION
Load .envrc file only when it exists on current directory.