### PR TITLE
Run in a child process (subshell) rather than on the same process

### DIFF
--- a/mac_with_apple_silicon
+++ b/mac_with_apple_silicon
@@ -95,8 +95,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/machupicchubeta/dotfiles/mai
 
 echo -e "\nApply private settings"
 if [ -f "$HOME/.mac.private" ]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.mac.private"
+  bash "$HOME/.mac.private"
 fi
 
 echo -e "\nUse zsh installed via Homebrew as default shell"

--- a/mac_with_intel_processor
+++ b/mac_with_intel_processor
@@ -89,8 +89,7 @@ fi
 
 echo -e "\nApply private settings"
 if [ -f "$HOME/.mac.private" ]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.mac.private"
+  bash "$HOME/.mac.private"
 fi
 
 echo -e "\nUse zsh installed via Homebrew as default shell"


### PR DESCRIPTION
Prevent operations in shell variables, environment variables, and scripts from affecting the current shell.